### PR TITLE
Add failing emotion test

### DIFF
--- a/advancedchatbot/__init__.py
+++ b/advancedchatbot/__init__.py
@@ -1,1 +1,5 @@
+from .chatbot_core import ChatbotCore
+from .chatbot_brain import ChatbotBrain
+
+__all__ = ["ChatbotCore", "ChatbotBrain"]
 

--- a/tests/test_emotions.py
+++ b/tests/test_emotions.py
@@ -1,0 +1,11 @@
+import pytest
+from advancedchatbot import ChatbotCore
+
+@pytest.mark.emotion
+def test_happy_emotion(tmp_path, monkeypatch):
+    # work within a temporary directory to avoid polluting real memory files
+    monkeypatch.chdir(tmp_path)
+    bot = ChatbotCore()
+    bot.chat(["I am happy"])
+    assert bot.memory["mood"] == "happy"
+


### PR DESCRIPTION
## Summary
- expose ChatbotCore and ChatbotBrain from package
- add a test to check that ChatbotCore updates mood when chatting

## Testing
- `python -m pytest -q` *(fails: neutral != happy)*

------
https://chatgpt.com/codex/tasks/task_e_684236004c908327a2461402f7869cf2