### PR TITLE
Fix README JSON block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ Send a message to the chatbot and receive a reply.
 {
   "message": "What is a Python list?"
 }
+```
+
 Response:
+
+```json
 {
   "reply": "A Python list is a collection of ordered items..."
 }
+```
 ---
 
 Made with ❤️ by **kkyian**  


### PR DESCRIPTION
## Summary
- fix code block formatting in README
- show API response example in its own block

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684235ff197c8327ae1aca4a3c429638