### PR TITLE
Fix DuckDuckGo link parsing

### DIFF
--- a/advancedchatbot/chatbot_core.py
+++ b/advancedchatbot/chatbot_core.py
@@ -68,7 +68,14 @@ class ChatbotCore:
                 link_start = html.find('href="', start) + 6
                 link_end = html.find('"', link_start)
                 link = html[link_start:link_end]
-                full_link = "https://duckduckgo.com" + link if link.startswith("/") else link
+
+                if link.startswith("//"):
+                    full_link = "https:" + link
+                elif link.startswith("/"):
+                    full_link = "https://duckduckgo.com" + link
+                else:
+                    full_link = link
+
                 return f"I found something! Here is a good link: {full_link}"
             else:
                 return f"I searched but couldn't find a direct link. Try here: https://duckduckgo.com/?q={query.replace(' ', '+')}"

--- a/advancedchatbot_installer/chatbot_core.py
+++ b/advancedchatbot_installer/chatbot_core.py
@@ -60,7 +60,14 @@ class ChatbotCore:
                 link_start = html.find('href="', start) + 6
                 link_end = html.find('"', link_start)
                 link = html[link_start:link_end]
-                full_link = "https://duckduckgo.com" + link if link.startswith("/") else link
+
+                if link.startswith("//"):
+                    full_link = "https:" + link
+                elif link.startswith("/"):
+                    full_link = "https://duckduckgo.com" + link
+                else:
+                    full_link = link
+
                 return f"I found something! Here is a good link: {full_link}"
             else:
                 return f"I searched but couldn't find a direct link. Try here: https://duckduckgo.com/?q={query.replace(' ', '+')}"


### PR DESCRIPTION
## Summary
- sanitize URLs returned from DuckDuckGo to avoid duplicated host prefix

## Testing
- `python -m py_compile advancedchatbot/chatbot_core.py advancedchatbot/chatbot_brain.py advancedchatbot_installer/chatbot_core.py advancedchatbot_installer/chatbot_brain.py api_server.py gui_chat.py main.py`
- `python - <<'PY'
from advancedchatbot.chatbot_core import ChatbotCore
bot=ChatbotCore()
print(bot.browse_web('open source python chatbot'))
PY
`
- `python - <<'PY'
from advancedchatbot.chatbot_core import ChatbotCore
bot=ChatbotCore()
print(bot.browse_web('python'))
PY
`


------
https://chatgpt.com/codex/tasks/task_e_6842342420508327a45aa3e2fc643dab