### PR TITLE
Improve loop detection

### DIFF
--- a/advancedchatbot/advancedchatbot_installer/chatbot_brain.py
+++ b/advancedchatbot/advancedchatbot_installer/chatbot_brain.py
@@ -4,7 +4,7 @@ class ChatbotBrain:
     def __init__(self):
         self.semantic_map = {
             "list": ["list", "array", "collection", "sequence"],
-            "loop": ["for", "while", "repeat", "iterate"],
+            "loop": ["loop", "loops", "for", "while", "repeat", "iterate"],
             "conditional": ["if", "condition", "branch", "decision"],
             "function": ["function", "method", "def", "procedure"],
             "class": ["class", "object", "blueprint"],

--- a/advancedchatbot/chatbot_brain.py
+++ b/advancedchatbot/chatbot_brain.py
@@ -4,7 +4,7 @@ class ChatbotBrain:
     def __init__(self):
         self.semantic_map = {
             "list": ["list", "array", "collection", "sequence"],
-            "loop": ["for", "while", "repeat", "iterate"],
+            "loop": ["loop", "loops", "for", "while", "repeat", "iterate"],
             "conditional": ["if", "condition", "branch", "decision"],
             "function": ["function", "method", "def", "procedure"],
             "class": ["class", "object", "blueprint"],

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -14,3 +14,13 @@ def test_greeting(tmp_path, monkeypatch):
     response = bot.chat('hello')
     assert 'Hello' in response
     assert memory_file.exists()
+
+def test_loop_detection(tmp_path, monkeypatch):
+    memory_file = tmp_path/'chatbot_memory.json'
+    monkeypatch.chdir(tmp_path)
+
+    bot = ChatbotCore()
+    response = bot.chat('Tell me about loops')
+
+    assert 'loop' in bot.memory['topics'][-1]
+    assert 'for i in range(5)' in response


### PR DESCRIPTION
## Summary
- expand `loop` synonyms so user queries like "loops" are recognized
- mirror changes for installer version
- add regression test for loop detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842402634248327b87c354db9d80a7e